### PR TITLE
fix(absolute-path): fix ambiguity in absolute-path vs line-comment

### DIFF
--- a/src/parser/grammar.js
+++ b/src/parser/grammar.js
@@ -844,6 +844,7 @@
         symbols: ['IPV4_OR_REG_NAME$ebnf$1'],
         postprocess: ipv4OrRegName,
       },
+      { name: 'ABSOLUTE_PATH', symbols: [{ literal: '/' }] },
       {
         name: 'ABSOLUTE_PATH$ebnf$1$subexpression$1',
         symbols: ['PATH_SEPARATOR', 'SEGMENT'],

--- a/src/parser/grammar.ne
+++ b/src/parser/grammar.ne
@@ -129,7 +129,7 @@ IPV4_OR_REG_NAME -> [^\s/:?#]:+ {% ipv4OrRegName %}
 # Resource path #
 #################
 
-ABSOLUTE_PATH -> (PATH_SEPARATOR SEGMENT):+ {% absolutePath %}
+ABSOLUTE_PATH -> "/" | (PATH_SEPARATOR SEGMENT):+ {% absolutePath %}
 
 PATH_SEPARATOR -> ("/" {% id %} | NEW_LINE_WITH_INDENT {% () => '\n' %}) {% pathSeparator %}
 

--- a/src/parser/postprocessors.js
+++ b/src/parser/postprocessors.js
@@ -243,11 +243,17 @@ const ipv4OrRegName = (data, location) =>
  */
 
 // absolutePath :: (Data, Location) -> AbsolutePath
-const absolutePath = (data, location) =>
-  cst.AbsolutePath({
-    location,
-    children: flatten(data),
-  });
+const absolutePath = (data, location, reject) => {
+  const children = flatten(data);
+  const absPath = children.reduce((acc, node) => acc + node.value, '');
+
+  // this is here to distinguish line comments from absolute paths
+  if (absPath.startsWith('//')) {
+    return reject;
+  }
+
+  return cst.AbsolutePath({ location, children });
+};
 
 // pathSeparator :: (Data, Location) -> PathSeparator
 const pathSeparator = (data, location) =>

--- a/test/corpus/corpus.js
+++ b/test/corpus/corpus.js
@@ -33,6 +33,7 @@ describe('corpus', function () {
 
         visit(astTree[0], visitor, { keyMap });
 
+        assert.lengthOf(astTree, 1);
         assert.strictEqual(visitor.result, astRep);
       });
     });

--- a/test/corpus/corpus.txt
+++ b/test/corpus/corpus.txt
@@ -206,20 +206,24 @@ GET http://www.example.com
 (requests-file
   (request
     (requests-line
+      (method)
       (request-target
-        (origin-form
-          (absolute-path
-            (path-separator)
-            (segment)
-            (path-separator)
-            (segment)))))
+        (absolute-form
+          (scheme)
+          (literal)
+          (hier-part
+            (authority
+              (host
+                (ipv4-or-reg-name)))))))
+    (headers
+      (header-field
+        (field-name)
+        (field-value))
+      (header-field
+        (field-name)
+        (field-value)))
     (message-body
       (messages
-        (message-line)
-        (message-line)
-        (message-line)
-        (message-line)
-        (message-line)
         (message-line)
         (message-line)))
     (response-handler

--- a/test/parser/fixtures/http/00000.http
+++ b/test/parser/fixtures/http/00000.http
@@ -1,7 +1,22 @@
+// test
 ### test
 
+//test
 
-POST https://httpbin.org/post HTTP/1.1
-Authorization: token
+GET http://www.example.com
+Header1: value1
+// test
+Header2: value2
+
+body
+
+> {% script %}
+<> file.json
+
+// test
+
+// test
+###
+GET http://www.example.com
 
 ###


### PR DESCRIPTION
Along with that tests are not detecting ambiguities in CST representation.

Closes #148

